### PR TITLE
Fix username string

### DIFF
--- a/cogs/signupClasses/skillDivsionDropdown.py
+++ b/cogs/signupClasses/skillDivsionDropdown.py
@@ -73,9 +73,7 @@ class SkillDivisionDropdown(discord.ui.Select):
                 await user.add_roles(normal_tournament_role)
                 await user.add_roles(division_role)
 
-                await finalized_signups.send(
-                    content=f"{user.name}{user.discriminator}"
-                )
+                await finalized_signups.send(content=str(user))
 
                 finalized_embed = discord.Embed(
                     title=f"Your sign-up was accepted by {interaction.user.name}",


### PR DESCRIPTION
This pull fixes username strings to look like this:
`xfuneralservicex0` -> `xfuneralservicex` (new discord username system have an extra "0" at the end)
`lowertiergod0854` -> `lowertiergod#0854` (old usernames are missing the hashtag before the discriminator)

![image](https://github.com/imptype/TC3-Discord-Bot/assets/106537315/9a671d5c-207d-4226-a490-8e81866aba6f)

Solution is to do `str(user)` from d.py server:
![image](https://github.com/imptype/TC3-Discord-Bot/assets/106537315/8b7da05d-1e6b-4b5c-9b5c-91fbef5db9f2)

https://github.com/Rapptz/discord.py/blob/master/discord/user.py#L101-L104
```py
    def __str__(self) -> str:
        if self.discriminator == '0':
            return self.name
        return f'{self.name}#{self.discriminator}'
```
