### PR TITLE
Fix discord import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,8 @@ creds.json
 
 # serverless-dependencies
 node_modules/
+
+# Editor files
+.vscode/
+.github/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# TC3 Discord Bot
+
+## This is the bot used in the [TC3 Discord Server](https://discord.gg/tc3).
+
+### Running
+1. Install [Python](https://www.python.org/downloads/) and [Git](https://git-scm.com/downloads)
+2. Clone the repository
+ - ```git clone https://github.com/Chess-Dude/TC3-Discord-Bot.git``` 
+3. install the necessary libraries onto your system
+ - ```pip install -r requirements.txt```
+4. Create a .env file with your discord bot token
+ - Put the line ```BOT_TOKEN=[your discord bot token]```
+5. Run the program ```python index.py```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@ async-timeout==4.0.2
 asyncpg==0.27.0
 beautifulsoup4==4.11.2
 bs4==0.0.1
-discord==2.1.0
-discord.py==2.2.2
+discord.py==2.3.0
 distlib==0.3.7
 google-auth==2.16.1
 google-auth-oauthlib==1.0.0


### PR DESCRIPTION
I removed `discord` package because it just points to `discord.py`, it's the same package so it's unnecessary to write that in.

I also made the version 2.3 because that's when `str(discord.User)` correctly returns `Username#0000` or `username` adjusting to the new discord user name system.